### PR TITLE
Hotfix/removes detected wallet

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -24,7 +24,6 @@ export function getLibrary(provider: any): Web3Provider {
 }
 
 const wallets = [
-  { walletName: 'detectedwallet', preferred: true },
   {
     walletName: 'keepkey',
     preferred: true,


### PR DESCRIPTION
- Removes the `detecedWallet` which bombs out onboard without metamask 