### PR TITLE
fix: improve opportunities page responsiveness

### DIFF
--- a/src/pages/Farm/Opportunities.tsx
+++ b/src/pages/Farm/Opportunities.tsx
@@ -65,9 +65,9 @@ export const Opportunities = () => {
             <Tr>
               <Th>Liquidity Pool</Th>
               <Th display={{ base: 'none', lg: 'table-cell' }}>Current APR</Th>
-              <Th display={{ base: 'none', lg: 'table-cell' }}>Liquidity</Th>
-              <Th display={{ base: 'none', lg: 'table-cell' }}>Network</Th>
-              <Th display={{ base: 'none', lg: 'table-cell' }}>Rewards</Th>
+              <Th display={{ base: 'none', md: 'table-cell' }}>Liquidity</Th>
+              <Th display={{ base: 'none', md: 'table-cell' }}>Network</Th>
+              <Th display={{ base: 'none', md: 'table-cell' }}>Rewards</Th>
               <Th display={{ base: 'none', md: 'table-cell' }}>Balance</Th>
               <Th />
             </Tr>
@@ -90,9 +90,9 @@ export const Opportunities = () => {
             <Tr>
               <Th>Asset</Th>
               <Th display={{ base: 'none', lg: 'table-cell' }}>Current APR</Th>
-              <Th display={{ base: 'none', lg: 'table-cell' }}>Deposits</Th>
-              <Th display={{ base: 'none', lg: 'table-cell' }}>Network</Th>
-              <Th display={{ base: 'none', lg: 'table-cell' }}>Rewards</Th>
+              <Th display={{ base: 'none', md: 'table-cell' }}>Deposits</Th>
+              <Th display={{ base: 'none', md: 'table-cell' }}>Network</Th>
+              <Th display={{ base: 'none', md: 'table-cell' }}>Rewards</Th>
               <Th display={{ base: 'none', md: 'table-cell' }}>Balance</Th>
               <Th />
             </Tr>
@@ -141,9 +141,9 @@ export const Opportunities = () => {
             <Tr>
               <Th>Asset</Th>
               <Th display={{ base: 'none', lg: 'table-cell' }}>Current APR</Th>
-              <Th display={{ base: 'none', lg: 'table-cell' }}>Deposits</Th>
-              <Th display={{ base: 'none', lg: 'table-cell' }}>Network</Th>
-              <Th display={{ base: 'none', lg: 'table-cell' }}>Rewards</Th>
+              <Th display={{ base: 'none', md: 'table-cell' }}>Deposits</Th>
+              <Th display={{ base: 'none', md: 'table-cell' }}>Network</Th>
+              <Th display={{ base: 'none', md: 'table-cell' }}>Rewards</Th>
               <Th display={{ base: 'none', md: 'table-cell' }}>Balance</Th>
               <Th />
             </Tr>

--- a/src/pages/Farm/Opportunities/ContractStakingRow.tsx
+++ b/src/pages/Farm/Opportunities/ContractStakingRow.tsx
@@ -118,15 +118,15 @@ export const ContractStakingRow = ({ contract }: StakingRowProps) => {
       <Td display={{ base: 'none', lg: 'table-cell' }}>
         <AprLabel apr={totalApr} isEnded={isEnded} periodFinish={contract.periodFinish} />
       </Td>
-      <Td display={{ base: 'none', lg: 'table-cell' }}>
+      <Td display={{ base: 'none', md: 'table-cell' }}>
         <Text>${numberFormatter(bnOrZero(totalStakedInContract).toNumber(), 2)}</Text>
       </Td>
-      <Td display={{ base: 'none', lg: 'table-cell' }}>
+      <Td display={{ base: 'none', md: 'table-cell' }}>
         <Tag colorScheme='purple' textTransform='capitalize'>
           {contract.network}
         </Tag>
       </Td>
-      <Td display={{ base: 'none', lg: 'table-cell' }}>
+      <Td display={{ base: 'none', md: 'table-cell' }}>
         <HStack>
           {contract.rewards?.map(reward => (
             <Image key={reward.symbol} boxSize='24px' src={reward.icon} />

--- a/src/pages/Farm/Opportunities/GenericStakingRow.tsx
+++ b/src/pages/Farm/Opportunities/GenericStakingRow.tsx
@@ -34,6 +34,23 @@ export const GenericStakingRow = ({
   aprFallbackLabel
 }: GenericStakingRowProps) => {
   const bg = useColorModeValue('gray.100', 'gray.750')
+  const renderApy = (size?: string) => {
+    return (
+      <>
+        {apy === null && aprFallbackLabel ? (
+          <Link href={url} isExternal>
+            <Tag colorScheme='gray'>{aprFallbackLabel}</Tag>
+          </Link>
+        ) : apy ? (
+          <>
+            <AprLabel size={size || 'md'} apr={apy ?? '-'} />
+          </>
+        ) : (
+          <Text>-</Text>
+        )}
+      </>
+    )
+  }
   return (
     <Tr _hover={{ bg }}>
       <Td>
@@ -60,26 +77,16 @@ export const GenericStakingRow = ({
             <Text color='gray.500' fontSize='sm' display={{ base: 'none', lg: 'table-cell' }}>
               {assetDescription}
             </Text>
-            <AprLabel apr={'2'} size='sm' display={{ base: 'inline-flex', lg: 'none' }} />
+            <Skeleton display={{ base: 'inline-flex', lg: 'none' }} isLoaded={apy !== undefined}>
+              {renderApy('sm')}
+            </Skeleton>
           </Box>
         </Flex>
       </Td>
       <Td display={{ base: 'none', lg: 'table-cell' }}>
-        <Skeleton isLoaded={apy !== undefined}>
-          {apy === null && aprFallbackLabel ? (
-            <Link href={url} isExternal>
-              <Tag colorScheme='gray'>{aprFallbackLabel}</Tag>
-            </Link>
-          ) : apy ? (
-            <>
-              <AprLabel apr={apy ?? '-'} />
-            </>
-          ) : (
-            <Text>-</Text>
-          )}
-        </Skeleton>
+        <Skeleton isLoaded={apy !== undefined}>{renderApy()}</Skeleton>
       </Td>
-      <Td display={{ base: 'none', lg: 'table-cell' }}>
+      <Td display={{ base: 'none', md: 'table-cell' }}>
         <Skeleton isLoaded={tvl !== undefined}>
           {tvl === null ? (
             <Text>-</Text>
@@ -88,12 +95,12 @@ export const GenericStakingRow = ({
           )}
         </Skeleton>
       </Td>
-      <Td display={{ base: 'none', lg: 'table-cell' }}>
+      <Td display={{ base: 'none', md: 'table-cell' }}>
         <Tag colorScheme='purple' textTransform='capitalize'>
           {network}
         </Tag>
       </Td>
-      <Td display={{ base: 'none', lg: 'table-cell' }}>
+      <Td display={{ base: 'none', md: 'table-cell' }}>
         <HStack>
           {rewardsImage ? <Image src={rewardsImage} boxSize='24px' /> : <Text>-</Text>}
         </HStack>

--- a/src/pages/Farm/Opportunities/PoolRow.tsx
+++ b/src/pages/Farm/Opportunities/PoolRow.tsx
@@ -67,15 +67,15 @@ export const PoolRow = ({ contract }: PoolRowProps) => {
       <Td display={{ base: 'none', lg: 'table-cell' }}>
         <AprLabel colorScheme='green' apr={lpApr} />
       </Td>
-      <Td display={{ base: 'none', lg: 'table-cell' }}>
+      <Td display={{ base: 'none', md: 'table-cell' }}>
         <Text>${numberFormatter(bnOrZero(totalInLiquidity).toNumber(), 2)}</Text>
       </Td>
-      <Td display={{ base: 'none', lg: 'table-cell' }}>
+      <Td display={{ base: 'none', md: 'table-cell' }}>
         <Tag colorScheme='purple' textTransform='capitalize'>
           {contract.network}
         </Tag>
       </Td>
-      <Td display={{ base: 'none', lg: 'table-cell' }}>
+      <Td display={{ base: 'none', md: 'table-cell' }}>
         <HStack>
           {contract.rewards?.map(reward => (
             <Image key={reward.symbol} boxSize='24px' src={reward.icon} />


### PR DESCRIPTION
Update the _Opportunities_ page to be responsive across the following breakpoints:

- `lg` (992px) and above: show all information
- `md`: (768px) replace asset description with APR, and condense into the asset box with `inline-flex`
- `sm` (480): show only APR and "Get started" button

See designs in https://github.com/shapeshift/foxfarm/issues/88 for the expected output.