### PR TITLE
feat: add ETH-FOX V3 staking opportunity

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -20,7 +20,6 @@ export const FEATURE_FLAGS = {
   airdrop: false,
   ethFoxStakingV1: true,
   ethFoxStakingV2: true,
-  // this must be set to true for testing
   ethFoxStakingV3: false
 }
 
@@ -122,11 +121,7 @@ export const stakingContracts = [
   {
     name: 'ETH-FOX V3',
     owner: 'ShapeShift',
-    contractAddress: '0xc54B9F82C1c54E9D4d274d633c7523f2299c42A0',
-    // test contract
-    // contractAddress: '0x6327fa640ecf1ab1967eb12c7b3494fc269a20b9',
-    // expired contract
-    // contractAddress: '0x7479831e095481cE46d378Ec6C5291e59BF25A76',
+    contractAddress: '0xc54B9F82C1c54E9D4d274d633c7523f2299c42A0', // TODO: Placeholder, update to actual V3 address when available
     pool: poolsContractData['0x470e8de2ebaef52014a47cb5e6af86884947f08c'],
     periodFinish: 1645714373,
     network: 'ethereum',

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -123,7 +123,7 @@ export const stakingContracts = [
     owner: 'ShapeShift',
     contractAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d', // TODO: Placeholder, update to actual V3 address when available
     pool: poolsContractData['0x470e8de2ebaef52014a47cb5e6af86884947f08c'],
-    periodFinish: 1645714373,
+    periodFinish: 1645714373, // TODO: this may need a change
     network: 'ethereum',
     balance: 0,
     rewards: [

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -121,7 +121,7 @@ export const stakingContracts = [
   {
     name: 'ETH-FOX V3',
     owner: 'ShapeShift',
-    contractAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d', // TODO: Placeholder, update to actual V3 address when available
+    contractAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
     pool: poolsContractData['0x470e8de2ebaef52014a47cb5e6af86884947f08c'],
     periodFinish: 1645714373, // TODO: this may need a change
     network: 'ethereum',

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -123,7 +123,7 @@ export const stakingContracts = [
     owner: 'ShapeShift',
     contractAddress: '0x212ebf9FD3c10F371557b08E993eAaB385c3932b',
     pool: poolsContractData['0x470e8de2ebaef52014a47cb5e6af86884947f08c'],
-    periodFinish: 1645714373, // TODO: this may need a change
+    periodFinish: 1655268529, // TODO: this may need a change
     network: 'ethereum',
     balance: 0,
     rewards: [

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -121,7 +121,7 @@ export const stakingContracts = [
   {
     name: 'ETH-FOX V3',
     owner: 'ShapeShift',
-    contractAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
+    contractAddress: '0x212ebf9FD3c10F371557b08E993eAaB385c3932b',
     pool: poolsContractData['0x470e8de2ebaef52014a47cb5e6af86884947f08c'],
     periodFinish: 1645714373, // TODO: this may need a change
     network: 'ethereum',

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -123,7 +123,7 @@ export const stakingContracts = [
     owner: 'ShapeShift',
     contractAddress: '0x212ebf9FD3c10F371557b08E993eAaB385c3932b',
     pool: poolsContractData['0x470e8de2ebaef52014a47cb5e6af86884947f08c'],
-    periodFinish: 1655268529, // TODO: this may need a change
+    periodFinish: 1657209600, // TODO: this may need a change
     network: 'ethereum',
     balance: 0,
     rewards: [

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -19,7 +19,9 @@ export const ICHI_ONEFOX_VAULT_API = 'https://api.ichi.org/v1/farms/20003'
 export const FEATURE_FLAGS = {
   airdrop: false,
   ethFoxStakingV1: true,
-  ethFoxStakingV2: true
+  ethFoxStakingV2: true,
+  // this must be set to true for testing
+  ethFoxStakingV3: false
 }
 
 type TokenProps = {
@@ -116,5 +118,25 @@ export const stakingContracts = [
       }
     ],
     enabled: FEATURE_FLAGS.ethFoxStakingV2
+  },
+  {
+    name: 'ETH-FOX V3',
+    owner: 'ShapeShift',
+    contractAddress: '0xc54B9F82C1c54E9D4d274d633c7523f2299c42A0',
+    // test contract
+    // contractAddress: '0x6327fa640ecf1ab1967eb12c7b3494fc269a20b9',
+    // expired contract
+    // contractAddress: '0x7479831e095481cE46d378Ec6C5291e59BF25A76',
+    pool: poolsContractData['0x470e8de2ebaef52014a47cb5e6af86884947f08c'],
+    periodFinish: 1645714373,
+    network: 'ethereum',
+    balance: 0,
+    rewards: [
+      {
+        symbol: 'FOX',
+        icon: 'https://assets.coincap.io/assets/icons/256/fox.png'
+      }
+    ],
+    enabled: FEATURE_FLAGS.ethFoxStakingV3
   }
 ] as StakingContractProps[]

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -121,7 +121,7 @@ export const stakingContracts = [
   {
     name: 'ETH-FOX V3',
     owner: 'ShapeShift',
-    contractAddress: '0xc54B9F82C1c54E9D4d274d633c7523f2299c42A0', // TODO: Placeholder, update to actual V3 address when available
+    contractAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d', // TODO: Placeholder, update to actual V3 address when available
     pool: poolsContractData['0x470e8de2ebaef52014a47cb5e6af86884947f08c'],
     periodFinish: 1645714373,
     network: 'ethereum',


### PR DESCRIPTION
this adds the ETH-FOX V3 staking opportunity but it currently points to the v2 opportunity as v3 does not exist yet and this was suggested in the issue concerning this pr (#90)

**NOTE:** `FEATURE_FLAGS.ethFoxStakingV3` in `src/lib/constants` needs to be set to `true` to test this out